### PR TITLE
Implement Twig_ExtensionInterface::getName

### DIFF
--- a/src/Twig/Extension.php
+++ b/src/Twig/Extension.php
@@ -51,4 +51,9 @@ class Extension extends Twig_Extension implements Twig_ExtensionInterface
     {
         return $this->pageSpecificCssService->buildExtractedRuleSet();
     }
+
+    public function getName()
+    {
+        return 'css-form-html-extractor';
+    }
 }


### PR DESCRIPTION
Class CSSFromHTMLExtractor\Twig\Extension contains 1 abstract method and
must therefore be declared abstract or implement the remaining methods
(Twig_ExtensionInterface::getName)