### PR TITLE
avoid warning that html is empty

### DIFF
--- a/src/CssFromHTMLExtractor.php
+++ b/src/CssFromHTMLExtractor.php
@@ -86,7 +86,9 @@ class CssFromHTMLExtractor
     {
         $document = new \DOMDocument('1.0', 'UTF-8');
         $internalErrors = libxml_use_internal_errors(true);
-        $document->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        if (!empty($html)) {
+            $document->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        }
         libxml_use_internal_errors($internalErrors);
         $document->formatOutput = true;
 


### PR DESCRIPTION
I agree that maybe we should not send an empty $html string to createDomDocumentFromHtml() but at least this does not cause it to emit a E_WARNING about it.