### PR TITLE
If no expression can be build, the selector is invalid

### DIFF
--- a/src/CssFromHTMLExtractor.php
+++ b/src/CssFromHTMLExtractor.php
@@ -149,6 +149,10 @@ class CssFromHTMLExtractor
 
                 $expression = $this->buildExpressionForSelector($rule->getSelector());
 
+                if (!$expression) {
+                    return false;
+                }
+
                 /** @var DOMNodeList $elements */
                 $elements = $xPath->query($expression);
 


### PR DESCRIPTION
This should resolve #8 