### PR TITLE
Fix fatal error when no cache provided in constructor

### DIFF
--- a/src/CssFromHTMLExtractor.php
+++ b/src/CssFromHTMLExtractor.php
@@ -56,7 +56,7 @@ class CssFromHTMLExtractor
         $this->cssConverter = new CssSelectorConverter();
 
         $this->resultCache = is_null($resultCache) ? new ArrayCache() : $resultCache;
-        $this->cachedRules = (array)$resultCache->fetch('cachedRules');
+        $this->cachedRules = (array)$this->resultCache->fetch('cachedRules');
     }
 
     public function getCssStore()


### PR DESCRIPTION
Just a simple fix for a recently added lines.
If there is no `$resultCache` provided in constructor then this line will cause a fatal error as it will try to execute `fetch()` on null.